### PR TITLE
Sending emails to players from a certain college

### DIFF
--- a/HVZ/HVZ/api/forms.py
+++ b/HVZ/HVZ/api/forms.py
@@ -14,10 +14,23 @@ class MailerForm(forms.Form):
 	ALLPLAYERS = "All"
 	HUMANS = "Humans"
 	ZOMBIES = "Zombies"
+	
+	# Schools
+	HMC = "HMC"
+	CMC = "CMC"
+	PITZER = "Pitzer"
+	POMONA = "Pomona"
+	SCRIPPS = "Scripps"
+	
 	CHOICES = [
 		(ALLPLAYERS, "All Players"),
 		(HUMANS, "Humans"),
 		(ZOMBIES, "Zombies"),
+		(HMC, "HMC"),
+		(CMC, "CMC"),
+		(PITZER, "Pitzer"),
+		(POMONA, "Pomona),
+		(SCRIPPS, "Scripps"),
 	]
 	# TODO: Should we make this a field in the email "form?"
 	

--- a/HVZ/HVZ/api/forms.py
+++ b/HVZ/HVZ/api/forms.py
@@ -22,6 +22,10 @@ class MailerForm(forms.Form):
 	POMONA = "Pomona"
 	SCRIPPS = "Scripps"
 	
+	# Initial version is just to add schools to the same dropdown menu
+	#
+	# Plan is to allow either another dropdown menu (just for schools) in addition to
+	# this one or allow for multiple options to be checked off or something similar
 	CHOICES = [
 		(ALLPLAYERS, "All Players"),
 		(HUMANS, "Humans"),

--- a/HVZ/HVZ/api/views.py
+++ b/HVZ/HVZ/api/views.py
@@ -75,7 +75,25 @@ class Mailer(FormView):
             recipients = [p.user.email for p in Player.current_players() if p.team == "H"]
 
         elif(recipient_title == MailerForm.ZOMBIES):
-            recipients = [p.user.email for p in Player.current_players() if p.team == "Z"]        
+            recipients = [p.user.email for p in Player.current_players() if p.team == "Z"]
+        
+        # option to send emails to players from a specific college
+        # should we add Keck and CGU as well?
+        elif(recipient_title == MailerForm.HMC):
+            recipients = [p.user.email for p in Player.current_players() if p.school.name == "Mudd"]
+            
+        elif(recipient_title == MailerForm.CMC):
+            recipients = [p.user.email for p in Player.current_players() if p.school.name == "CMC"]
+            
+        elif(recipient_title == MailerForm.PITZER):
+            recipients = [p.user.email for p in Player.current_players() if p.school.name == "Pitzer"]
+            
+        elif(recipient_title == MailerForm.POMONA):
+            recipients = [p.user.email for p in Player.current_players() if p.school.name == "Pomona"]
+            
+        elif(recipient_title == MailerForm.SCRIPPS):
+            recipients = [p.user.email for p in Player.current_players() if p.school.name == "Scripps"]
+            
         
         # TODO: Authentication error for sender for mod@claremonthvz.org
         mailBag = EmailMessage(subject, body, sender, [], recipients)


### PR DESCRIPTION
This is for the feature to send emails to players from a certain college. There are a few comments in the file, but I plan on also changing the selection of colleges to maybe a checkbox or a different dropdown menu (instead of just being in the same one as All Players/Humans/Zombies). The goal is to allow for multiple colleges to be selected as well as to allow for the selection of All Players/Humans/Zombies in addition to college (e.g. all the humans from HMC). Let me know if this doesn't work in your fork for some reason and I'll make appropriate changes.